### PR TITLE
Fix loading invisible previews

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -292,17 +292,6 @@ function escapeHTML(text) {
 					+'</div>' + "\n";
 			}
 
-			if (activity.previews && activity.previews.length) {
-				content += '<div class="activity-previews">';
-				for (var i = 0; i < activity.previews.length; i++) {
-					var preview = activity.previews[i];
-					content += ((preview.link) ? '<a href="' + preview.link + '">' + "\n" : '')
-						+ '<img class="preview' + ((preview.isMimeTypeIcon) ? ' preview-mimetype-icon' : '') + '" src="' + preview.source + '" alt="' + t('activity', 'Open {filename}', preview) + '" />' + "\n"
-						+ ((preview.link) ? '</a>' + "\n" : '')
-				}
-				content += '</div>';
-			}
-
 			content += '	</div>' + "\n"
 				+'</div>';
 


### PR DESCRIPTION
The previews are currently disabled on the activity page with display:
none in the CSS. This is causing issues since the previews are still
loaded even though they are invisible.